### PR TITLE
Better types definitions to avoid casting as unknown

### DIFF
--- a/src/base-filter.ts
+++ b/src/base-filter.ts
@@ -69,7 +69,7 @@ export default abstract class BaseFilter {
    * Save the current structure as a JSON object
    */
   saveAsJSON(): Object {
-    throw new Error('Not Implemented')
+    throw new Error('not-implemented')
   }
 
   /**
@@ -77,7 +77,7 @@ export default abstract class BaseFilter {
    * @param json the JSON object to load
    * @return Return the Object loaded from the provided JSON object 
    */
-  static fromJSON(json: any): BaseFilter {
-    throw new Error('Not Implemented')
+  static fromJSON(json: any): any {
+    throw new Error('not-implemented')
   }
 }

--- a/src/base-filter.ts
+++ b/src/base-filter.ts
@@ -68,7 +68,7 @@ export default abstract class BaseFilter {
   /**
    * Save the current structure as a JSON object
    */
-  saveAsJSON() {
+  saveAsJSON(): Object {
     throw new Error('Not Implemented')
   }
 
@@ -77,7 +77,7 @@ export default abstract class BaseFilter {
    * @param json the JSON object to load
    * @return Return the Object loaded from the provided JSON object 
    */
-  static fromJSON(json: any) {
+  static fromJSON(json: any): BaseFilter {
     throw new Error('Not Implemented')
   }
 }


### PR DESCRIPTION
In the title, related to #20 

Allows to do: `const b: BloomFilter = BloomFilter.fromJSON(bloomJSON) as BloomFilter`
Instead of doing this ...: `const b: BloomFilter = BloomFilter.fromJSON(bloomJSON) as unknown as BloomFilter`

**Edit: see https://github.com/Callidon/bloom-filters/issues/20#issuecomment-799799655**