### PR TITLE
Import/export from bytes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -433,3 +433,29 @@ export function power2 (x: number): number {
 export function hex2bin (hex: string): string {
   return parseInt(hex, 16).toString(2)
 }
+
+/**
+ * Convert an uint8 to an array of 1s and 0s
+ * @param  uint8  - A uint8 number
+ * @return An array of 1s and 0s
+ */
+export function uint8ToBits (uint8: number): number[] {
+  return [128,64,32,16,8,4,2,1].map(x => (x & uint8) > 0 ? 1 : 0)
+}
+
+/**
+ * Convert an array of 1s and 0s to a uint8
+ * @param  bits  - An array of 1s and 0s
+ * @return A uint8 number
+ */
+export function bitsToUint8 (bits: number[]): number {
+  return bits.reduce((acc, cur, i) => {
+    if(cur === 0){
+      return acc
+    }else if (cur === 1){
+      return acc + Math.pow(2, 7-i)
+    }else {
+      throw new Error("Not binary")
+    }
+  }, 0)
+}

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -134,6 +134,19 @@ describe('BloomFilter', () => {
     })
   })
 
+  describe('Import/Export from bytes', () => {
+    const filter = new BloomFilter(128, 8)
+    filter.add('test')
+    filter.add('another')
+    filter.add('one more')
+    const bytes = filter.toBytes()
+    const recreated = BloomFilter.fromBytes(bytes, 8)
+
+    it('should equal itself when exported to a buffer and re-created', () => {
+      filter.equals(recreated).should.equal(true)
+    }) 
+  })
+
   describe('Performance test', () => {
     const max = 1000
     const targetedRate = 0.01


### PR DESCRIPTION
Thank you for this library!

In our use case, we need to export & store bloom filters as byte arrays as well as re-import them as bloom filters to add additional elements.

I've added functions/tests for doing both.

This does change the API of the constructor, as it takes the `filter` as an array of bits instead of a `size`. However, I added an additional static function `empty` that replicates the functionality of the existing constructor. 

I also had to remove the `_length` check from `equals` since if we import from a byte array, we don't know how many objects are in a bloom filter.

We're currently only using the `bloom-filter` implementation, so I only made the changes in that location. However, if you are interested, I can make the changes to the rest of the implementations so that the APIs match. Let me know! :grin: 