### PR TITLE
Use the buffer npm package for browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,45 @@
 # Bloom-Filters
-[![Build Status](https://travis-ci.com/Callidon/bloom-filters.svg?branch=master)](https://travis-ci.com/Callidon/bloom-filters)
-
 JavaScript/TypeScript implementation of probabilistic data structures: Bloom Filter (and its derived), HyperLogLog, Count-Min Sketch, Top-K and MinHash.
 **This package rely on [non-cryptographic hash functions](https://cyan4973.github.io/xxHash/)**.
 
 📕[Online documentation](https://callidon.github.io/bloom-filters/)
 
+A fork of [bloom-filters](https://github.com/Callidon/bloom-filters) that adds the ability to import/export filters from a buffer.
+
 **Keywords:** *bloom filter, cuckoo filter, KyperLogLog, MinHash, Top-K, probabilistic data-structures.*
 
 # Table of contents
 
-* [Installation](#installation)
-* [Data structures](#data-structures)
-	* [Classic Bloom Filter](#classic-bloom-filter)
-	* [Partitioned Bloom Filter](#partitioned-bloom-filter)
-	* [Cuckoo Filter](#cuckoo-filter)
-	* [Counting Bloom Filter](#counting-bloom-filter)
-	* [Count Min Sketch](#count-min-sketch)
-	* [HyperLogLog](#hyperloglog)
-	* [MinHash](#minhash)
-	* [Top-K](#top-k)
-  * [Invertible Bloom Filters](#invertible-bloom-filters)
-* [Export and import](#export-and-import)
-* [Documentation](#documentation)
-* [Tests](#tests)
-* [References](#references)
-* [Changelog](#changelog)
-* [License](#license)
+- [Bloom-Filters](#bloom-filters)
+- [Table of contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Data structures](#data-structures)
+    - [Classic Bloom Filter](#classic-bloom-filter)
+      - [Methods](#methods)
+    - [Partitioned Bloom Filter](#partitioned-bloom-filter)
+      - [Methods](#methods-1)
+    - [Cuckoo Filter](#cuckoo-filter)
+      - [Methods](#methods-2)
+    - [Counting Bloom Filter](#counting-bloom-filter)
+      - [Methods](#methods-3)
+    - [Count Min Sketch](#count-min-sketch)
+      - [Methods](#methods-4)
+    - [HyperLogLog](#hyperloglog)
+      - [Methods](#methods-5)
+    - [MinHash](#minhash)
+      - [`MinHashFactory` methods](#minhashfactory-methods)
+      - [`MinHash` methods](#minhash-methods)
+    - [Top-K](#top-k)
+      - [Methods](#methods-6)
+    - [Invertible Bloom Filters](#invertible-bloom-filters)
+      - [Methods](#methods-7)
+  - [Export and import](#export-and-import)
+  - [Every hash function is seeded](#every-hash-function-is-seeded)
+  - [Documentation](#documentation)
+  - [Tests](#tests)
+  - [References](#references)
+  - [Changelog](#changelog)
+  - [License](#license)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "is-buffer": "^2.0.4",
     "lodash": "^4.17.15",
     "lodash.eq": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "bloom-filters",
-  "version": "1.3.1",
+  "name": "fission-bloom-filters",
+  "version": "1.4.0",
   "description": "JS implementation of probabilistic data structures: Bloom Filter (and its derived), HyperLogLog, Count-Min Sketch, Top-K and MinHash",
   "main": "dist/api.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-bloom-filters",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "JS implementation of probabilistic data structures: Bloom Filter (and its derived), HyperLogLog, Count-Min Sketch, Top-K and MinHash",
   "main": "dist/api.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-bloom-filters",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "JS implementation of probabilistic data structures: Bloom Filter (and its derived), HyperLogLog, Count-Min Sketch, Top-K and MinHash",
   "main": "dist/api.js",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Callidon/bloom-filters.git"
+    "url": "https://github.com/fission-suite/bloom-filters"
   },
   "keywords": [
     "bloom",
@@ -23,8 +23,9 @@
     "count min sketch",
     "cuckoo"
   ],
-  "author": "Thomas Minier <thomas.minier@protonmail.com>",
+  "author": "Daniel Holmgren <daniel@fission.codes",
   "contributors": [
+    "Thomas Minier <thomas.minier@protonmail.com>",
     "Arnaud Grall <dev.arnaudgrall@gmail.com>"
   ],
   "license": "MIT",

--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -113,10 +113,10 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
    * Import an existing bloom filter from a Uint8Array
    * @param bytes - The existing bloom filter as Uint8Array
    * @param nbHashes - The number of hash functions used
-   * @return A {@link BloomFilter} from the buffer
+   * @return A {@link BloomFilter} from the bytes array
    */
 
-  static fromBuffer(bytes: Uint8Array, nbHashes: number) {
+  static fromBytes(bytes: Uint8Array, nbHashes: number) {
     let filter = [] as number[]
     for(let i = 0; i < bytes.length; i++) {
       const bits = uint8ToBits(bytes[i])
@@ -203,7 +203,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
    * Exports to a Uint8Array
    * @return Uint8Array of filter
    */
-  toBuffer (): Uint8Array {
+  toBytes (): Uint8Array {
     const arr = new Uint8Array(Math.ceil(this._size / 8))
     for(let i=0; i < arr.length; i++) {
       const bits = this._filter.slice(i*8, i*8 + 8)

--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -110,17 +110,16 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   }
 
   /**
-   * Import an existing bloom filter from an ArrayBuffer
-   * @param buf - The existing bloom filter as ArrayBuffer
+   * Import an existing bloom filter from a Uint8Array
+   * @param bytes - The existing bloom filter as Uint8Array
    * @param nbHashes - The number of hash functions used
    * @return A {@link BloomFilter} from the buffer
    */
 
-  static fromBuffer(buf: ArrayBuffer, nbHashes: number) {
-    const arr = new Uint8Array(buf)
+  static fromBuffer(bytes: Uint8Array, nbHashes: number) {
     let filter = [] as number[]
-    for(let i = 0; i < arr.length; i++) {
-      const bits = uint8ToBits(arr[i])
+    for(let i = 0; i < bytes.length; i++) {
+      const bits = uint8ToBits(bytes[i])
       filter = filter.concat(bits)
     }
     return new BloomFilter(filter, nbHashes)
@@ -201,15 +200,15 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   }
 
   /**
-   * Exports to an ArrayBuffer
-   * @return ArrayBuffer of filter
+   * Exports to a Uint8Array
+   * @return Uint8Array of filter
    */
-  toBuffer (): ArrayBuffer {
+  toBuffer (): Uint8Array {
     const arr = new Uint8Array(Math.ceil(this._size / 8))
     for(let i=0; i < arr.length; i++) {
       const bits = this._filter.slice(i*8, i*8 + 8)
       arr[i] = bitsToUint8(bits)
     }
-    return arr.buffer
+    return arr
   }
 }

--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -55,7 +55,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
 
   /**
    * Constructor
-   * @param size - The number of cells
+   * @param filter - The filter as an array of 1s & 0s
    * @param nbHashes - The number of hash functions used
    */
   constructor (@Parameter('_filter') filter: Array<number>, @Parameter('_nbHashes') nbHashes: number) {
@@ -108,6 +108,13 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
     array.forEach(element => filter.add(element))
     return filter
   }
+
+  /**
+   * Import an existing bloom filter from an ArrayBuffer
+   * @param buf - The existing bloom filter as ArrayBuffer
+   * @param nbHashes - The number of hash functions used
+   * @return A {@link BloomFilter} from the buffer
+   */
 
   static fromBuffer(buf: ArrayBuffer, nbHashes: number) {
     const arr = new Uint8Array(buf)
@@ -193,6 +200,10 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
     return this._filter.every((value, index) => other._filter[index] === value)
   }
 
+  /**
+   * Exports to an ArrayBuffer
+   * @return ArrayBuffer of filter
+   */
   toBuffer (): ArrayBuffer {
     const arr = new Uint8Array(Math.ceil(this._size / 8))
     for(let i=0; i < arr.length; i++) {

--- a/src/iblt/cell.ts
+++ b/src/iblt/cell.ts
@@ -24,6 +24,7 @@ SOFTWARE.
 
 'use strict'
 
+import { Buffer } from 'buffer'
 import { hashTwiceAsString, xorBuffer } from '../utils'
 import { AutoExportable, Field, Parameter } from '../exportable'
 import BaseFilter from '../base-filter'

--- a/src/iblt/invertible-bloom-lookup-tables.ts
+++ b/src/iblt/invertible-bloom-lookup-tables.ts
@@ -24,6 +24,7 @@ SOFTWARE.
 
 'use strict'
 
+import { Buffer } from 'buffer'
 import BaseFilter from '../base-filter'
 import WritableFilter from '../interfaces/writable-filter'
 import Cell from './cell'

--- a/src/sketch/hyperloglog.ts
+++ b/src/sketch/hyperloglog.ts
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import { Buffer } from 'buffer'
 import BaseFilter from '../base-filter'
 import { AutoExportable, Field, Parameter } from '../exportable'
 import { HashableInput, allocateArray, hashAsInt } from '../utils'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,7 @@ SOFTWARE.
 'use strict'
 
 import XXH from 'xxhashjs'
+import { Buffer } from 'buffer'
 
 /**
  * Utilitaries functions

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -434,10 +434,20 @@ export function hex2bin (hex: string): string {
   return parseInt(hex, 16).toString(2)
 }
 
+/**
+ * Convert an uint8 to an array of 1s and 0s
+ * @param  uint8  - A uint8 number
+ * @return An array of 1s and 0s
+ */
 export function uint8ToBits (uint8: number): number[] {
   return [128,64,32,16,8,4,2,1].map(x => (x & uint8) > 0 ? 1 : 0)
 }
 
+/**
+ * Convert an array of 1s and 0s to a uint8
+ * @param  bits  - An array of 1s and 0s
+ * @return A uint8 number
+ */
 export function bitsToUint8 (bits: number[]): number {
   return bits.reduce((acc, cur, i) => {
     if(cur === 0){

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -433,3 +433,19 @@ export function power2 (x: number): number {
 export function hex2bin (hex: string): string {
   return parseInt(hex, 16).toString(2)
 }
+
+export function uint8ToBits (uint8: number): number[] {
+  return [128,64,32,16,8,4,2,1].map(x => (x & uint8) > 0 ? 1 : 0)
+}
+
+export function bitsToUint8 (bits: number[]): number {
+  return bits.reduce((acc, cur, i) => {
+    if(cur === 0){
+      return acc
+    }else if (cur === 1){
+      return acc + Math.pow(2, 7-i)
+    }else {
+      throw new Error("Not binary")
+    }
+  }, 0)
+}

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -26,6 +26,7 @@ SOFTWARE.
 
 require('chai').should()
 const { BloomFilter } = require('../dist/api.js')
+const { uint8ToBits, bitsToUint8 } = require('../dist/utils.js')
 
 describe('BloomFilter', () => {
   const targetRate = 0.1
@@ -74,14 +75,14 @@ describe('BloomFilter', () => {
     })
 
     it('should returns False when two filters have different sizes', () => {
-      const first = new BloomFilter(15, 4)
-      const other = new BloomFilter(10, 4)
+      const first = BloomFilter.empty(15, 4)
+      const other = BloomFilter.empty(10, 4)
       first.equals(other).should.equal(false)
     })
 
     it('should returns False when two filters have different nb. of hash functions', () => {
-      const first = new BloomFilter(15, 4)
-      const other = new BloomFilter(15, 2)
+      const first = BloomFilter.empty(15, 4)
+      const other = BloomFilter.empty(15, 2)
       first.equals(other).should.equal(false)
     })
 
@@ -132,6 +133,19 @@ describe('BloomFilter', () => {
         (() => BloomFilter.fromJSON(json)).should.throw(Error)
       })
     })
+  })
+
+  describe('Import/Export from buffers', () => {
+    const filter = BloomFilter.empty(128, 8)
+    filter.add('test')
+    filter.add('another')
+    filter.add('one more')
+    const buf = filter.toBuffer()
+    const recreated = BloomFilter.fromBuffer(buf, 8)
+
+    it('should equal itself when exported to a buffer and re-created', () => {
+      filter.equals(recreated).should.equal(true)
+    }) 
   })
 
   describe('Performance test', () => {

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -140,8 +140,8 @@ describe('BloomFilter', () => {
     filter.add('test')
     filter.add('another')
     filter.add('one more')
-    const buf = filter.toBuffer()
-    const recreated = BloomFilter.fromBuffer(buf, 8)
+    const bytes = filter.toBytes()
+    const recreated = BloomFilter.fromBytes(bytes, 8)
 
     it('should equal itself when exported to a buffer and re-created', () => {
       filter.equals(recreated).should.equal(true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -114,6 +119,14 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 camelcase@^5.0.0:
   version "5.3.1"
@@ -373,6 +386,11 @@ highlight.js@^9.17.1:
   version "9.18.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
When building `webnative`, we have to inject the `Buffer` class from the `buffer` library when building for node.

With this PR, that won't be necessary anymore. Instead, the bloom-filters library will just use the `buffer` library. In node, it'll just expose the node-native Buffer class.
