### PR TITLE
Fix import of inner count min for TopK import

### DIFF
--- a/src/sketch/topk.ts
+++ b/src/sketch/topk.ts
@@ -146,7 +146,10 @@ export default class TopK extends BaseFilter {
   @Field()
   private _accuracy: number
 
-  @Field()
+  @Field<CountMinSketch>(
+    (sketch: CountMinSketch) => sketch.saveAsJSON(),
+    (json: any) => CountMinSketch.fromJSON(json)
+  )
   private _sketch: CountMinSketch
 
   @Field<MinHeap>((heap: MinHeap) => heap.content, (json: any) => {

--- a/test/topk-test.js
+++ b/test/topk-test.js
@@ -285,5 +285,26 @@ describe('TopK', () => {
         (() => TopK.fromJSON(json)).should.throw(Error)
       })
     })
+
+    it('should update an imported TopK', ()=>{
+      const exported = topk.saveAsJSON()
+      const newSketch = TopK.fromJSON(exported)
+      
+      newSketch.add("alice")
+      topk.add("alice")
+      
+      newSketch._k.should.equal(topk._k)
+      newSketch._errorRate.should.equal(topk._errorRate)
+      newSketch._accuracy.should.equal(topk._accuracy)
+      newSketch._seed.should.equal(topk._seed)
+      // inner count min sketch
+      newSketch._sketch._columns.should.equal(topk._sketch._columns)
+      newSketch._sketch._rows.should.equal(topk._sketch._rows)
+      newSketch._sketch._allSums.should.equal(topk._sketch._allSums)
+      newSketch._sketch._seed.should.equal(topk._sketch._seed)
+      newSketch._sketch._matrix.should.deep.equal(topk._sketch._matrix)
+      // inner MinHeap
+      newSketch._heap._content.should.deep.equal(topk._heap._content)
+    })
   })
 })


### PR DESCRIPTION
Hello, thanks for creating this library! It's been very helpful.

I'm currently working with the TopK data structure and encountered a bug.
It seems that it's throwing this error whenever I am trying to update an imported TopK.

```
TypeError: this._sketch.update is not a function
```

This is the code for the bug replication 
https://stackblitz.com/edit/node-kcv3z7?file=index.js

```js
// Initialize topK
const topk = new TopK(k, error_rate, accuracy);
topk.add('Alice');
topk.add('Bob');

// Save topk
const json = topk.saveAsJSON();
const str = JSON.stringify(json);

// Import topK
const new_topk = TopK.fromJSON(JSON.parse(str));

// Update topk
new_topk.add('Carl');  // this throws
```

I figured that this might be due to the inner count-min sketch not being properly initialized during import. 

I am not that confident that I understand what the decorators do, but based on how the inner heap is imported I made the following fix in the TopK class.

```ts
@Field<CountMinSketch>(
  (sketch: CountMinSketch) => sketch.saveAsJSON(),
  (json: any) => CountMinSketch.fromJSON(json)
)
private _sketch: CountMinSketch
```

I also made the corresponding tests for this. I hope this fixes the bug.