### PR TITLE
use filter's length as the number of bits currently set for better rate calculation

### DIFF
--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -106,7 +106,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   }
 
   /**
-   * Get the number of elements currently in the filter
+   * Get the number of bits currently set in the filter
    * @return The filter length
    */
   get length (): number {
@@ -123,9 +123,11 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   add (element: HashableInput): void {
     const indexes = getDistinctIndices(element, this._size, this._nbHashes, this.seed)
     for (let i = 0; i < indexes.length; i++) {
+      if (!this._filter[indexes[i]]) {
+        this._length++
+      }
       this._filter[indexes[i]] = 1
     }
-    this._length++
   }
 
   /**
@@ -156,7 +158,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
    * console.log(filter.rate()); // output: something around 0.1
    */
   rate (): number {
-    return Math.pow(1 - Math.exp((-this._nbHashes * this._length) / this._size), this._nbHashes)
+    return Math.pow(1 - Math.exp(-this._length / this._size), this._nbHashes)
   }
 
   /**

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -37,7 +37,9 @@ describe('BloomFilter', () => {
       filter.seed = seed
       filter.add('alice')
       filter.add('bob')
-      filter.length.should.equal(2)
+      filter.add('alice') // duplicate item
+      filter.length.should.greaterThan(0)
+      filter.length.should.be.at.most(filter._nbHashes * 2)
     })
 
     it('should build a new filter using #from', () => {
@@ -47,7 +49,8 @@ describe('BloomFilter', () => {
       const filter = BloomFilter.from(data, targetRate)
       filter.size.should.equal(expectedSize)
       filter._nbHashes.should.equal(expectedHashes)
-      filter.length.should.equal(data.length)
+      filter.length.should.greaterThan(0)
+      filter.length.should.be.at.most(filter._nbHashes * data.length)
       filter.rate().should.be.closeTo(targetRate, 0.1)
     })
   })


### PR DESCRIPTION
adding duplicated items to the filter should not increase the false-positive rate