### PR TITLE
BitSet-backed Bloom filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "base64-arraybuffer": "^1.0.1",
     "is-buffer": "^2.0.4",
     "lodash": "^4.17.15",
     "lodash.eq": "^4.0.0",

--- a/src/bloom/bit-set.ts
+++ b/src/bloom/bit-set.ts
@@ -1,0 +1,81 @@
+/* file : BitSet.ts
+MIT License
+
+Copyright (c) 2021 David Leppik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/** A memory-efficient Boolean array. Contains just the minimal operations needed for our Bloom filter implementation.
+ *
+ * @author David Leppik
+ */
+
+const bitsPerWord = 8;
+
+export default class BitSet {
+    public readonly size: number;
+
+    // Uint32Array may be slightly faster due to memory alignment, but this avoids endianness when serializing
+    private readonly array: Uint8Array;
+
+    constructor(size: number) {
+        this.size = size
+        this.array = new Uint8Array(Math.ceil(size / bitsPerWord))
+    }
+
+    has(index: number): boolean {
+        const word = Math.floor(index / bitsPerWord)
+        const mask = 1 << (index % bitsPerWord)
+        return (this.array[word] & mask) !== 0
+    }
+
+    add(index: number) {
+        const word = Math.floor(index / bitsPerWord)
+        const mask = 1 << (index % bitsPerWord)
+        this.array[word] = this.array[word] | mask
+    }
+
+    remove(index: number) {
+        const word = Math.floor(index / bitsPerWord)
+        const mask = 1 << (index % bitsPerWord)
+        this.array[word] = this.array[word] ^ mask
+    }
+
+    /** Returns the maximum set bit. */
+    max(): number {
+        for (let i = this.array.length - 1; i >= 0; i--) {
+            let bits = this.array[i];
+            if (bits) {
+                return BitSet.highBit(bits) + (i*bitsPerWord);
+            }
+        }
+        return 0;
+    }
+
+    private static highBit(bits : number) : number {
+        let result = bitsPerWord - 1;
+        let mask = 1 << result;
+        while (result >= 0 && ((mask & bits) !== mask)) {
+            mask >>>= 1;
+            result--;
+        }
+        return result;
+    }
+}

--- a/src/bloom/bit-set.ts
+++ b/src/bloom/bit-set.ts
@@ -67,16 +67,6 @@ export default class BitSet {
     }
 
     /**
-     * Set the bit to false
-     * @param index position of the bit, zero-indexed
-     */
-    remove(index: number) {
-        const wordIndex = Math.floor(index / bitsPerWord)
-        const mask = 1 << (index % bitsPerWord)
-        this.array[wordIndex] = this.array[wordIndex] ^ mask
-    }
-
-    /**
      * Returns the maximum true bit.
      */
     max(): number {

--- a/src/bloom/bit-set.ts
+++ b/src/bloom/bit-set.ts
@@ -26,7 +26,8 @@ import {encode, decode} from "base64-arraybuffer";
 
 const bitsPerWord = 8;
 
-/** A memory-efficient Boolean array. Contains just the minimal operations needed for our Bloom filter implementation.
+/**
+ * A memory-efficient Boolean array. Contains just the minimal operations needed for our Bloom filter implementation.
  *
  * @author David Leppik
  */
@@ -45,7 +46,8 @@ export default class BitSet {
         this.array = new Uint8Array(Math.ceil(size / bitsPerWord))
     }
 
-    /** Returns the value of the bit at the given index
+    /**
+     * Returns the value of the bit at the given index
      * @param index position of the bit, zero-indexed
      */
     has(index: number): boolean {
@@ -54,7 +56,8 @@ export default class BitSet {
         return (this.array[wordIndex] & mask) !== 0
     }
 
-    /** Set the bit to true
+    /**
+     * Set the bit to true
      * @param index position of the bit, zero-indexed
      */
     add(index: number) {
@@ -63,7 +66,8 @@ export default class BitSet {
         this.array[wordIndex] = this.array[wordIndex] | mask
     }
 
-    /** Set the bit to false
+    /**
+     * Set the bit to false
      * @param index position of the bit, zero-indexed
      */
     remove(index: number) {
@@ -72,7 +76,9 @@ export default class BitSet {
         this.array[wordIndex] = this.array[wordIndex] ^ mask
     }
 
-    /** Returns the maximum true bit. */
+    /**
+     * Returns the maximum true bit.
+     */
     max(): number {
         for (let i = this.array.length - 1; i >= 0; i--) {
             let bits = this.array[i];
@@ -83,7 +89,9 @@ export default class BitSet {
         return 0;
     }
 
-    /** Returns the number of true bits. */
+    /**
+     * Returns the number of true bits.
+     */
     bitCount(): number {
         let result = 0
         for (let i = 0; i < this.array.length; i++) {

--- a/src/bloom/bit-set.ts
+++ b/src/bloom/bit-set.ts
@@ -32,7 +32,7 @@ import {encode, decode} from "base64-arraybuffer";
 const bitsPerWord = 8;
 
 export default class BitSet {
-    public readonly size: number;
+    readonly size: number;
 
     // Uint32Array may be slightly faster due to memory alignment, but this avoids endianness when serializing
     private array: Uint8Array;
@@ -94,7 +94,7 @@ export default class BitSet {
     public export(): BitSetData {
         return {
             size: this.size,
-            base64: encode(this.array)
+            content: encode(this.array)
         }
     }
 
@@ -102,8 +102,11 @@ export default class BitSet {
         if (typeof data.size !== "number") {
             throw Error("BitSet missing size")
         }
+        if (typeof data.content !== "string") {
+            throw Error("BitSet: missing content")
+        }
         const result = new BitSet(data.size)
-        const buffer = decode(data.base64)
+        const buffer = decode(data.content)
         result.array = new Uint8Array(buffer)
         return result
     }
@@ -130,5 +133,5 @@ export default class BitSet {
 
 interface BitSetData {
     size: number
-    base64: string
+    content: string
 }

--- a/src/bloom/bit-set.ts
+++ b/src/bloom/bit-set.ts
@@ -108,7 +108,9 @@ export default class BitSet {
         return true
     }
 
-    /** Returns a JSON-encodable object readable by {@link import}. */
+    /** 
+     * Returns a JSON-encodable object readable by {@link import}. 
+     */
     export(): { size: number, content: string } {
         return {
             size: this.size,

--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -26,9 +26,10 @@ SOFTWARE.
 
 import ClassicFilter from '../interfaces/classic-filter'
 import BaseFilter from '../base-filter'
+import BitSet from "./bit-set";
 import { AutoExportable, Field, Parameter } from '../exportable'
 import { optimalFilterSize, optimalHashes } from '../formulas'
-import { HashableInput, allocateArray, getDistinctIndices } from '../utils'
+import { HashableInput, getDistinctIndices } from '../utils'
 
 /**
  * A Bloom filter is a space-efficient probabilistic data structure, conceived by Burton Howard Bloom in 1970,
@@ -42,16 +43,13 @@ import { HashableInput, allocateArray, getDistinctIndices } from '../utils'
 @AutoExportable<BloomFilter>('BloomFilter', ['_seed'])
 export default class BloomFilter extends BaseFilter implements ClassicFilter<HashableInput> {
   @Field()
-  private _size: number
+  private readonly _size: number
 
   @Field()
-  private _nbHashes: number
+  private readonly _nbHashes: number
 
-  @Field()
-  private _filter: Array<number>
-
-  @Field()
-  private _length: number
+  @Field<BitSet>(f => f.export(), d => BitSet.import(d))
+  private readonly _filter: BitSet
 
   /**
    * Constructor
@@ -65,13 +63,12 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
     }
     this._size = size
     this._nbHashes = nbHashes
-    this._filter = allocateArray(this._size, 0)
-    this._length = 0
+    this._filter = new BitSet(size)
   }
 
   /**
    * Create an optimal bloom filter providing the maximum of elements stored and the error rate desired
-   * @param  items      - The maximum nuber of item to store
+   * @param  nbItems      - The maximum number of item to store
    * @param  errorRate  - The error rate desired for a maximum of items inserted
    * @return A new {@link BloomFilter}
    */
@@ -84,7 +81,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   /**
    * Build a new Bloom Filter from an existing iterable with a fixed error rate
    * @param items - The iterable used to populate the filter
-   * @param errorRate - The error rate, i.e. 'false positive' rate, targetted by the filter
+   * @param errorRate - The error rate, i.e. 'false positive' rate, targeted by the filter
    * @return A new Bloom Filter filled with the iterable's elements
    * @example
    * // create a filter with a false positive rate of 0.1
@@ -110,7 +107,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
    * @return The filter length
    */
   get length (): number {
-    return this._length
+    return this._filter.bitCount()
   }
 
   /**
@@ -123,10 +120,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   add (element: HashableInput): void {
     const indexes = getDistinctIndices(element, this._size, this._nbHashes, this.seed)
     for (let i = 0; i < indexes.length; i++) {
-      if (!this._filter[indexes[i]]) {
-        this._length++
-      }
-      this._filter[indexes[i]] = 1
+      this._filter.add(indexes[i]);
     }
   }
 
@@ -143,7 +137,7 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
   has (element: HashableInput): boolean {
     const indexes = getDistinctIndices(element, this._size, this._nbHashes, this.seed)
     for (let i = 0; i < indexes.length; i++) {
-      if (!this._filter[indexes[i]]) {
+      if (!this._filter.has(indexes[i])) {
         return false
       }
     }
@@ -158,18 +152,18 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
    * console.log(filter.rate()); // output: something around 0.1
    */
   rate (): number {
-    return Math.pow(1 - Math.exp(-this._length / this._size), this._nbHashes)
+    return Math.pow(1 - Math.exp(-this.length / this._size), this._nbHashes)
   }
 
   /**
    * Check if another Bloom Filter is equal to this one
-   * @param  filter - The filter to compare to this one
+   * @param  other - The filter to compare to this one
    * @return True if they are equal, false otherwise
    */
   equals (other: BloomFilter): boolean {
-    if (this._size !== other._size || this._nbHashes !== other._nbHashes || this._length !== other._length) {
+    if (this._size !== other._size || this._nbHashes !== other._nbHashes) {
       return false
     }
-    return this._filter.every((value, index) => other._filter[index] === value)
+    return this._filter.equals(other._filter)
   }
 }

--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -82,14 +82,18 @@ export default class BloomFilter extends BaseFilter implements ClassicFilter<Has
    * Build a new Bloom Filter from an existing iterable with a fixed error rate
    * @param items - The iterable used to populate the filter
    * @param errorRate - The error rate, i.e. 'false positive' rate, targeted by the filter
+   * @param seed - The random number seed (optional)
    * @return A new Bloom Filter filled with the iterable's elements
    * @example
    * // create a filter with a false positive rate of 0.1
    * const filter = BloomFilter.from(['alice', 'bob', 'carl'], 0.1);
    */
-  static from (items: Iterable<HashableInput>, errorRate: number): BloomFilter {
+  static from (items: Iterable<HashableInput>, errorRate: number, seed?: number): BloomFilter {
     const array = Array.from(items)
     const filter = BloomFilter.create(array.length, errorRate)
+    if (typeof seed === 'number') {
+      filter.seed = seed
+    }
     array.forEach(element => filter.add(element))
     return filter
   }

--- a/test/bit-set-test.js
+++ b/test/bit-set-test.js
@@ -50,12 +50,69 @@ describe('BitSet', () => {
         }
     })
 
-    it('finds the high bit', () => {
-        const set = new BitSet(150)
-        set.size.should.equal(150)
-        for (let i=0; i<set.size; i++) {
+    describe('#max', () => {
+        it('finds the high bit', () => {
+            const set = new BitSet(150)
+            set.size.should.equal(150)
+            for (let i=0; i<set.size; i++) {
+                set.add(i)
+                set.max().should.equal(i)
+            }
+        })
+    })
+
+    it('imports what it exports', () => {
+        const set = new BitSet(50)
+        for (let i=0; i < set.size; i += 3) { // 3 is relatively prime to 8, so should hit all edge cases
             set.add(i)
-            set.max().should.equal(i)
         }
+        const exported = set.export()
+        const imported = BitSet.import(exported)
+        imported.size.should.equal(set.size)
+        for (i=0; i < set.size; i++) {
+            let expected = i % 3 === 0;
+            set.has(i).should.equal(expected)
+        }
+    })
+
+    describe('#equals', () => {
+        it('returns true on identical size and data', () => {
+            let a = new BitSet(50)
+            let b = new BitSet(50)
+            a.equals(b).should.equal(true)
+            for (let i=0; i < a.size; i += 3) {  // 3 is relatively prime to 8, so should hit all edge cases
+                a.add(i)
+                b.add(i)
+                a.equals(b).should.equal(true)
+            }
+        })
+
+        it('returns false on different size', () => {
+            new BitSet(50).equals(new BitSet(150)).should.equal(false)
+        })
+
+        it('returns false on different data', () => {
+            let a = new BitSet(50)
+            let b = new BitSet(50)
+            a.add(3)
+            a.equals(b).should.equal(false)
+            a.remove(3)
+            a.equals(b).should.equal(true)
+            a.add(49)
+            a.equals(b).should.equal(false)
+        })
+    })
+
+    describe('#bitCount', () => {
+        it('counts the number of bits', () => {
+            let set = new BitSet(50)
+            let expectedCount = 0
+            set.bitCount().should.equal(expectedCount)
+            for (let i = 0; i < set.size; i += 3) {
+                set.add(i)
+                expectedCount++
+                set.bitCount().should.equal(expectedCount)
+            }
+        })
     })
 })

--- a/test/bit-set-test.js
+++ b/test/bit-set-test.js
@@ -35,18 +35,13 @@ describe('BitSet', () => {
         }
     })
 
-    it('reads and clears set values', () => {
+    it('#add', () => {
         const set = new BitSet(50)
         set.size.should.equal(50)
         for (let i = 0; i < set.size; i++) {
             set.has(i).should.equal(false)
             set.add(i)
             set.has(i).should.equal(true)
-        }
-        for (let i = 0; i < set.size; i++) {
-            set.has(i).should.equal(true)
-            set.remove(i)
-            set.has(i).should.equal(false)
         }
     })
 
@@ -110,7 +105,7 @@ describe('BitSet', () => {
             let b = new BitSet(50)
             a.add(3)
             a.equals(b).should.equal(false)
-            a.remove(3)
+            a = new BitSet(50)
             a.equals(b).should.equal(true)
             a.add(49)
             a.equals(b).should.equal(false)

--- a/test/bit-set-test.js
+++ b/test/bit-set-test.js
@@ -1,7 +1,7 @@
-/* file : api.ts
+/* file : bit-set-test.js
 MIT License
 
-Copyright (c) 2017-2020 Thomas Minier & Arnaud Grall
+Copyright (c) 2021 David Leppik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-'use strict'
 
-export { default as BloomFilter } from './bloom/bloom-filter'
-export { default as CountingBloomFilter } from './bloom/counting-bloom-filter'
-export { default as PartitionedBloomFilter } from './bloom/partitioned-bloom-filter'
-export { default as BitSet } from './bloom/bit-set'
-export { default as CountMinSketch } from './sketch/count-min-sketch'
-export { default as HyperLogLog } from './sketch/hyperloglog'
-export { default as TopK } from './sketch/topk'
-export { MinHash } from './sketch/min-hash'
-export { default as MinHashFactory } from './sketch/min-hash-factory'
-export { default as CuckooFilter } from './cuckoo/cuckoo-filter'
-export { default as InvertibleBloomFilter } from './iblt/invertible-bloom-lookup-tables'
-export { default as Cell } from './iblt/cell'
+require('chai').should()
+const { BitSet } = require('../dist/api')
+
+describe('BitSet', () => {
+    it('is initially clear', () => {
+        const set = new BitSet(50)
+        set.size.should.equal(50)
+        for (let i=0; i<set.size; i++) {
+            set.has(i).should.equal(false)
+        }
+    })
+
+    it('reads and clears set values', () => {
+        const set = new BitSet(50)
+        set.size.should.equal(50)
+        for (let i=0; i<set.size; i++) {
+            set.has(i).should.equal(false)
+            set.add(i)
+            set.has(i).should.equal(true)
+        }
+        for (let i=0; i<set.size; i++) {
+            set.has(i).should.equal(true)
+            set.remove(i)
+            set.has(i).should.equal(false)
+        }
+    })
+
+    it('finds the high bit', () => {
+        const set = new BitSet(150)
+        set.size.should.equal(150)
+        for (let i=0; i<set.size; i++) {
+            set.add(i)
+            set.max().should.equal(i)
+        }
+    })
+})

--- a/test/bit-set-test.js
+++ b/test/bit-set-test.js
@@ -61,18 +61,33 @@ describe('BitSet', () => {
         })
     })
 
-    it('imports what it exports', () => {
-        const set = new BitSet(50)
-        for (let i=0; i < set.size; i += 3) { // 3 is relatively prime to 8, so should hit all edge cases
-            set.add(i)
-        }
-        const exported = set.export()
-        const imported = BitSet.import(exported)
-        imported.size.should.equal(set.size)
-        for (i=0; i < set.size; i++) {
-            let expected = i % 3 === 0;
-            set.has(i).should.equal(expected)
-        }
+    describe("#import, #export", () => {
+        it('imports what it exports', () => {
+            const set = new BitSet(50)
+            for (let i = 0; i < set.size; i += 3) { // 3 is relatively prime to 8, so should hit all edge cases
+                set.add(i)
+            }
+            const exported = set.export()
+            const imported = BitSet.import(exported)
+            imported.size.should.equal(set.size)
+            for (let i = 0; i < set.size; i++) {
+                let expected = i % 3 === 0;
+                set.has(i).should.equal(expected)
+            }
+        })
+
+        describe('#import', () => {
+            it('Throws an Error on bad data', () => {
+                [
+                    {size: 1},
+                    {content: 'Ag=='},
+                    {size: 'cow', content: 'Ag=='}
+                ].forEach(json => {
+                    console.log(json)
+                    ;(() => BitSet.import(json)).should.throw(Error)
+                })
+            })
+        })
     })
 
     describe('#equals', () => {

--- a/test/bit-set-test.js
+++ b/test/bit-set-test.js
@@ -30,7 +30,7 @@ describe('BitSet', () => {
     it('is initially clear', () => {
         const set = new BitSet(50)
         set.size.should.equal(50)
-        for (let i=0; i<set.size; i++) {
+        for (let i = 0; i < set.size; i++) {
             set.has(i).should.equal(false)
         }
     })
@@ -38,12 +38,12 @@ describe('BitSet', () => {
     it('reads and clears set values', () => {
         const set = new BitSet(50)
         set.size.should.equal(50)
-        for (let i=0; i<set.size; i++) {
+        for (let i = 0; i < set.size; i++) {
             set.has(i).should.equal(false)
             set.add(i)
             set.has(i).should.equal(true)
         }
-        for (let i=0; i<set.size; i++) {
+        for (let i = 0; i < set.size; i++) {
             set.has(i).should.equal(true)
             set.remove(i)
             set.has(i).should.equal(false)
@@ -54,7 +54,7 @@ describe('BitSet', () => {
         it('finds the high bit', () => {
             const set = new BitSet(150)
             set.size.should.equal(150)
-            for (let i=0; i<set.size; i++) {
+            for (let i = 0; i < set.size; i++) {
                 set.add(i)
                 set.max().should.equal(i)
             }
@@ -82,10 +82,9 @@ describe('BitSet', () => {
                     {size: 1},
                     {content: 'Ag=='},
                     {size: 'cow', content: 'Ag=='}
-                ].forEach(json => {
-                    console.log(json)
-                    ;(() => BitSet.import(json)).should.throw(Error)
-                })
+                ].forEach(json =>
+                    (() => BitSet.import(json)).should.throw(Error)
+                )
             })
         })
     })
@@ -95,7 +94,7 @@ describe('BitSet', () => {
             let a = new BitSet(50)
             let b = new BitSet(50)
             a.equals(b).should.equal(true)
-            for (let i=0; i < a.size; i += 3) {  // 3 is relatively prime to 8, so should hit all edge cases
+            for (let i = 0; i < a.size; i += 3) {  // 3 is relatively prime to 8, so should hit all edge cases
                 a.add(i)
                 b.add(i)
                 a.equals(b).should.equal(true)

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -102,6 +102,7 @@ describe('BloomFilter', () => {
       exported._seed.should.equal(filter.seed)
       exported.type.should.equal('BloomFilter')
       exported._size.should.equal(filter.size)
+      exported._nbHashes.should.equal(filter._nbHashes)
       exported._filter.should.deep.equal(filter._filter.export())
     })
 
@@ -119,13 +120,11 @@ describe('BloomFilter', () => {
 
     it('should reject imports from invalid JSON objects', () => {
       const invalids = [
-        { type: 'something' },
-        { type: 'BloomFilter' },
-        { type: 'BloomFilter', _size: 1 },
-        { type: 'BloomFilter', _size: 1, _seed: 1 },
-        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {} },
-        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {size: 1, base64: "error, not actually base64"} },
-        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {size: 1, base64: "error, not actually base64"} },
+        { type: 'wrong', _size: 1, _nbHashes: 2, _seed: 1, _filter: {size: 1, content: 'AA=='} },
+        { type: 'BloomFilter', _nbHashes: 2, _seed: 1, _filter: {size: 1, content: 'AA=='} },
+        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {size: 1, content: 'AA=='} },
+        { type: 'BloomFilter', _size: 1, _nbHashes: 2, _filter: {size: 1, content: 'AA=='} },
+        { type: 'BloomFilter', _size: 1, _nbHashes: 2, _seed: 1 }
       ]
 
       invalids.forEach(json => {

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -102,9 +102,7 @@ describe('BloomFilter', () => {
       exported._seed.should.equal(filter.seed)
       exported.type.should.equal('BloomFilter')
       exported._size.should.equal(filter.size)
-      exported._length.should.equal(filter.length)
-      exported._nbHashes.should.equal(filter._nbHashes)
-      exported._filter.should.deep.equal(filter._filter)
+      exported._filter.should.deep.equal(filter._filter.export())
     })
 
     it('should create a bloom filter from a JSON export', () => {
@@ -116,8 +114,6 @@ describe('BloomFilter', () => {
       const newFilter = BloomFilter.fromJSON(exported)
       newFilter.seed.should.equal(filter.seed)
       newFilter.size.should.equal(filter._size)
-      newFilter.length.should.equal(filter._length)
-      newFilter._nbHashes.should.equal(filter._nbHashes)
       newFilter._filter.should.deep.equal(filter._filter)
     })
 
@@ -126,9 +122,10 @@ describe('BloomFilter', () => {
         { type: 'something' },
         { type: 'BloomFilter' },
         { type: 'BloomFilter', _size: 1 },
-        { type: 'BloomFilter', _size: 1, _length: 1 },
-        { type: 'BloomFilter', _size: 1, _length: 1, _nbHashes: 2 },
-        { type: 'BloomFilter', _size: 1, _length: 1, _nbHashes: 2, seed: 1 }
+        { type: 'BloomFilter', _size: 1, _seed: 1 },
+        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {} },
+        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {size: 1, base64: "error, not actually base64"} },
+        { type: 'BloomFilter', _size: 1, _seed: 1, _filter: {size: 1, base64: "error, not actually base64"} },
       ]
 
       invalids.forEach(json => {

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -52,6 +52,7 @@ describe('BloomFilter', () => {
       filter.length.should.greaterThan(0)
       filter.length.should.be.at.most(filter._nbHashes * data.length)
       filter.rate().should.be.closeTo(targetRate, 0.1)
+      filter.seed.should.equal(0x1234567890) // utils.getDefaultSeed()
     })
   })
 

--- a/test/bloom-filter-test.js
+++ b/test/bloom-filter-test.js
@@ -149,11 +149,11 @@ describe('BloomFilter', () => {
       for (let i = max; i < max * 11; ++i) {
         tries++
         current = i
-        const has = filter.has('' + current, true)
+        const has = filter.has('' + current)
         if (has) falsePositive++
       }
-      const currentrate = falsePositive / tries
-      currentrate.should.be.closeTo(targetedRate, targetedRate)
+      const currentRate = falsePositive / tries
+      currentRate.should.be.closeTo(targetedRate, targetedRate)
     })
   })
 })


### PR DESCRIPTION
BloomFilter uses a TypedArray-backed BitSet which is 64x more space efficient. Serialization uses base64-arraybuffer, which is the only new dependency.

I added BitSet to api.ts's exports for unit test access.  That wasn't my first inclination, but I didn't see a different way to access a class from dist. 

I've tried to follow the style of the rest of the classes, with two exceptions. Class properties in BitSet are not backed by _underscored fields, as the TypeScript Handbook explicitly recommends otherwise. (Adding a backing field can be done without an API change, removing one can require more code changes. Omitting the backing field yields, if anything, slightly more efficient JavaScript.) Second, BitSet is not AutoExportable although it could be. I ultimately decided that because it is a low-level data structure, it is better to have the flexibility and compactness of an explicit serializer/deserializer.

BTW, it turns out the problem creating a pull request before was related to authentication problems on my end. Sorry for the inconvenience!