### PR TITLE
Update release job with npm environment

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: 
+      name: npm
+      url: https://www.npmjs.com/package/bloom-filters
     steps:
     - uses: actions/checkout@v2
     # Setup .npmrc file to publish to npm


### PR DESCRIPTION
The goal of this PR is to use a dedicated `npm` environment for deployment. It allow use to isolates the deploy secret so it is only available for deploy (and not in other jobs) and add a validation step to allow the release when a new tag is created.