### PR TITLE
[Bugfix] bad seed import in cuckoo filter

### DIFF
--- a/src/cuckoo/cuckoo-filter.ts
+++ b/src/cuckoo/cuckoo-filter.ts
@@ -96,7 +96,7 @@ function computeFingerpintLength(size: number, rate: number): number {
       })
       return bucket
     })
-    filter.seed = json.seed
+    filter.seed = json._seed
     return filter
     /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
   },

--- a/test/count-min-sketch-test.js
+++ b/test/count-min-sketch-test.js
@@ -109,6 +109,7 @@ describe('CountMinSketch', () => {
     it('should create a count-min sketch from a JSON export', () => {
       const exported = sketch.saveAsJSON()
       const newSketch = CountMinSketch.fromJSON(exported)
+      newSketch.seed.should.equal(sketch.seed)
       newSketch.columns.should.equal(sketch.columns)
       newSketch.rows.should.equal(sketch.rows)
       newSketch.sum.should.be.equal(sketch.sum)

--- a/test/cuckoo-filter-test.js
+++ b/test/cuckoo-filter-test.js
@@ -253,6 +253,7 @@ describe('CuckooFilter', () => {
     it('should create a cuckoo filter from a JSON export', () => {
       const exported = filter.saveAsJSON()
       const newFilter = CuckooFilter.fromJSON(exported)
+      newFilter.seed.should.equal(filter.seed)
       newFilter.size.should.equal(filter.size)
       newFilter.fingerprintLength.should.equal(filter.fingerprintLength)
       newFilter.length.should.equal(filter.length)

--- a/test/hyperloglog-test.js
+++ b/test/hyperloglog-test.js
@@ -119,6 +119,7 @@ describe('HyperLogLog', () => {
     it('should create an HyperLogLog from a JSON export', () => {
       const exported = sketch.saveAsJSON()
       const newFilter = HyperLogLog.fromJSON(exported)
+      newFilter.seed.should.equal(sketch.seed)
       newFilter._nbRegisters.should.equal(sketch._nbRegisters)
       newFilter._nbBytesPerHash.should.equal(sketch._nbBytesPerHash)
       newFilter._correctionBias.should.equal(sketch._correctionBias)

--- a/test/iblt-test.js
+++ b/test/iblt-test.js
@@ -151,6 +151,7 @@ describe('Invertible Bloom Lookup Tables', () => {
       const exported = iblt.saveAsJSON()
       const newIblt = InvertibleBloomFilter.fromJSON(exported)
       iblt.equals(newIblt).should.equals(true)
+      newIblt.seed.should.equal(iblt.seed)
     })
 
     it('should reject imports from invalid JSON objects', () => {

--- a/test/min-hash-test.js
+++ b/test/min-hash-test.js
@@ -142,6 +142,7 @@ describe('MinHash', () => {
     it('should create a MinHash from a JSON export', () => {
       const exported = mySet.saveAsJSON()
       const newSet = MinHash.fromJSON(exported)
+      newSet.seed.should.equal(mySet.seed)
       newSet._nbHashes.should.equal(mySet._nbHashes)
       newSet._hashFunctions.should.deep.equal(mySet._hashFunctions)
       newSet._signature.should.deep.equal(mySet._signature)

--- a/test/partitioned-bloom-filter-test.js
+++ b/test/partitioned-bloom-filter-test.js
@@ -140,6 +140,7 @@ describe('PartitionedBloomFilter', () => {
       const filter = getFilter()
       const exported = filter.saveAsJSON()
       const newFilter = PartitionedBloomFilter.fromJSON(exported)
+      newFilter.seed.should.equal(filter.seed)
       newFilter._capacity.should.equal(filter._capacity)
       newFilter._size.should.equal(filter._size)
       newFilter._loadFactor.should.equal(filter._loadFactor)

--- a/test/scalable-bloom-filter-test.js
+++ b/test/scalable-bloom-filter-test.js
@@ -83,6 +83,7 @@ describe('ScalableBloomFilter', () => {
       }
       const exported = filter.saveAsJSON()
       const imported = ScalableBloomFilter.fromJSON(exported)
+      imported.seed.should.equal(filter.seed)
       imported.equals(filter).should.equal(true)
       for (let i = 0; i < 50; i++) {
         imported.has('elem:' + i).should.equal(true)

--- a/test/xor-filter-test.js
+++ b/test/xor-filter-test.js
@@ -69,6 +69,7 @@ describe('XorFilter', () => {
       const json = filter.saveAsJSON()
       const newFilter = XorFilter.fromJSON(json)
       filter.equals(newFilter)
+      filter.seed.should.equal(newFilter.seed)
     })
   })
 })


### PR DESCRIPTION
## Summary
The goal for this PR is to fix a bug where the seed of the cuckoo filter were badly imported.

Associated issue: https://github.com/Callidon/bloom-filters/issues/64

### Changes

* import correctly the `json._seed` from the exported cuckoo filter.
* add more specific tests about the seed for the other filters