### PR TITLE
chore(hashing): use only @node-rs/xxhash with bigint(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,8 +200,7 @@
     "is-buffer": "^2.0.5",
     "lodash": "^4.17.21",
     "reflect-metadata": "^0.2.2",
-    "seedrandom": "^3.0.5",
-    "xxhashjs": "^0.2.2"
+    "seedrandom": "^3.0.5"
   },
   "prettier": {
     "semi": false,

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,7 +23,7 @@ SOFTWARE.
 */
 
 // For documentation
-export {type HashableInput as HashableInput} from './utils'
+export {type HashableInput as HashableInput} from './types'
 
 // export all default
 export {default as BaseFilter} from './base-filter'

--- a/src/base-filter.ts
+++ b/src/base-filter.ts
@@ -8,7 +8,7 @@ import {getDefaultSeed} from './utils'
  * @author Arnaud Grall
  */
 export default abstract class BaseFilter {
-  public _seed: number
+  public _seed: bigint
   public _rng: PRNG
   public _hashing: Hashing
 
@@ -21,7 +21,7 @@ export default abstract class BaseFilter {
   /**
    * Get the seed used in this structure
    */
-  public get seed(): number {
+  public get seed(): bigint {
     return this._seed
   }
 
@@ -29,7 +29,7 @@ export default abstract class BaseFilter {
    * Set the seed for this structure
    * @param  seed the new seed that will be used in this structure
    */
-  public set seed(seed: number) {
+  public set seed(seed: bigint) {
     this._seed = seed
     this._rng = seedrandom(`${this._seed}`)
   }

--- a/src/bloom/bloom-filter.ts
+++ b/src/bloom/bloom-filter.ts
@@ -2,13 +2,15 @@ import ClassicFilter from '../interfaces/classic-filter'
 import BaseFilter from '../base-filter'
 import BitSet, {ExportedBitSet} from './bit-set'
 import {optimalFilterSize, optimalHashes} from '../formulas'
-import {HashableInput} from '../utils'
+import {exportBigInt, importBigInt} from '../utils'
+import {ExportedBigInt} from '../types'
+import {HashableInput, SeedType} from '../types'
 
 export type ExportedBloomFilter = {
   _size: number
   _nbHashes: number
   _filter: ExportedBitSet
-  _seed: number
+  _seed: ExportedBigInt
 }
 
 /**
@@ -72,11 +74,11 @@ export default class BloomFilter
   public static from(
     items: Iterable<HashableInput>,
     errorRate: number,
-    seed?: number
+    seed?: SeedType
   ): BloomFilter {
     const array = Array.from(items)
     const filter = BloomFilter.create(array.length, errorRate)
-    if (typeof seed === 'number') {
+    if (seed) {
       filter.seed = seed
     }
     array.forEach(element => filter.add(element))
@@ -177,13 +179,13 @@ export default class BloomFilter
       _size: this._size,
       _nbHashes: this._nbHashes,
       _filter: this._filter.export(),
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
     }
   }
 
   public static fromJSON(element: ExportedBloomFilter): BloomFilter {
     const bl = new BloomFilter(element._size, element._nbHashes)
-    bl.seed = element._seed
+    bl.seed = importBigInt(element._seed)
     const data = element._filter
     if (Array.isArray(data)) {
       const bs = new BitSet(data.length)

--- a/src/bloom/counting-bloom-filter.ts
+++ b/src/bloom/counting-bloom-filter.ts
@@ -1,10 +1,12 @@
 import BaseFilter from '../base-filter'
 import WritableFilter from '../interfaces/writable-filter'
 import {optimalFilterSize, optimalHashes} from '../formulas'
-import {HashableInput, allocateArray} from '../utils'
+import {allocateArray, exportBigInt, importBigInt} from '../utils'
+import {ExportedBigInt} from '../types'
+import {HashableInput} from '../types'
 
 export type ExportedCountingBloomFilter = {
-  _seed: number
+  _seed: ExportedBigInt
   _size: number
   _nbHashes: number
   _filter: number[][]
@@ -219,7 +221,7 @@ export default class CountingBloomFilter
       _size: this._size,
       _nbHashes: this._nbHashes,
       _filter: this._filter,
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
     }
   }
 
@@ -227,7 +229,7 @@ export default class CountingBloomFilter
     element: ExportedCountingBloomFilter
   ): CountingBloomFilter {
     const bl = new CountingBloomFilter(element._size, element._nbHashes)
-    bl.seed = element._seed
+    bl.seed = importBigInt(element._seed)
     bl._length = element._length
     bl._filter = element._filter
     return bl

--- a/src/bloom/partitioned-bloom-filter.ts
+++ b/src/bloom/partitioned-bloom-filter.ts
@@ -1,11 +1,12 @@
 import BaseFilter from '../base-filter.js'
 import ClassicFilter from '../interfaces/classic-filter.js'
-import {HashableInput, allocateArray} from '../utils.js'
-import {SeedType} from '../types.js'
+import {allocateArray, exportBigInt, importBigInt} from '../utils.js'
+import {ExportedBigInt} from '../types.js'
+import {HashableInput, SeedType} from '../types.js'
 import BitSet, {ExportedBitSet} from './bit-set.js'
 
 export type ExportedPartitionedBloomFilter = {
-  _seed: number
+  _seed: ExportedBigInt
   _bits: number
   _k: number
   _m: number
@@ -192,7 +193,7 @@ export default class PartitionedBloomFilter
       _bits: this._bits,
       _k: this._k,
       _filter: this._filter.map(m => m.export()),
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
       _m: this._m,
       _errorRate: this._errorRate,
     }
@@ -206,7 +207,7 @@ export default class PartitionedBloomFilter
       element._k,
       element._errorRate
     )
-    bl.seed = element._seed
+    bl.seed = importBigInt(element._seed)
     bl._m = element._m
     bl._filter = element._filter.map(b => BitSet.import(b))
     return bl

--- a/src/bloom/scalable-bloom-filter.ts
+++ b/src/bloom/scalable-bloom-filter.ts
@@ -1,14 +1,15 @@
 import ClassicFilter from '../interfaces/classic-filter.js'
 import BaseFilter from '../base-filter.js'
-import {SeedType} from '../types.js'
+import {HashableInput, SeedType} from '../types.js'
 import PartitionBloomFilter, {
   ExportedPartitionedBloomFilter,
 } from './partitioned-bloom-filter.js'
 import seedrandom from 'seedrandom'
-import {HashableInput} from '../utils.js'
+import {exportBigInt, importBigInt} from '../utils.js'
+import {ExportedBigInt} from '../types.js'
 
 export type ExportedScalableBloomFilter = {
-  _seed: number
+  _seed: ExportedBigInt
   _initial_size: number
   _initial_error_rate: number
   _ratio: number
@@ -186,7 +187,7 @@ export default class ScalableBloomFilter
       _initial_size: this._initial_size,
       _initial_error_rate: this._initial_error_rate,
       _filters: this._filters.map(filter => filter.saveAsJSON()),
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
       _ratio: this._ratio,
     }
   }
@@ -199,7 +200,7 @@ export default class ScalableBloomFilter
       element._initial_error_rate,
       element._ratio
     )
-    bl.seed = element._seed
+    bl.seed = importBigInt(element._seed)
     bl._filters = element._filters.map(filter =>
       PartitionBloomFilter.fromJSON(filter)
     )

--- a/src/bloom/xor-filter.ts
+++ b/src/bloom/xor-filter.ts
@@ -1,10 +1,6 @@
 import BaseFilter from '../base-filter.js'
-import {
-  allocateArray,
-  exportBigInt,
-  ExportedBigInt,
-  importBigInt,
-} from '../utils.js'
+import {allocateArray, exportBigInt, importBigInt} from '../utils.js'
+import {ExportedBigInt} from '../types.js'
 import {HashableInput, SeedType} from '../types.js'
 import {xxh3} from '@node-rs/xxhash'
 
@@ -14,7 +10,7 @@ export type ExportedXorFilter = {
   _bits: XorSize
   _size: number
   _blockLength: number
-  _seed: number
+  _seed: ExportedBigInt
 }
 
 /**
@@ -158,13 +154,13 @@ export default class XorFilter extends BaseFilter {
    */
   public _create(elements: HashableInput[]) {
     // work only on bigint(s)
-    this.seed = 0
+    this.seed = 0n
 
     const reverseOrder: bigint[] = allocateArray(this._size, 0n)
     const reverseH: number[] = allocateArray(this._size, 0)
     let reverseOrderPos
     do {
-      this.seed = this.nextInt32()
+      this.seed = BigInt(this.nextInt32())
       const t2count = allocateArray(this._filter.length, 0)
       const t2 = allocateArray(this._filter.length, 0n)
       elements.forEach(k => {
@@ -301,7 +297,7 @@ export default class XorFilter extends BaseFilter {
       _bits: this._bits,
       _blockLength: this._blockLength,
       _filter: this._filter.map(e => exportBigInt(e)),
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
     }
   }
 
@@ -311,7 +307,7 @@ export default class XorFilter extends BaseFilter {
    */
   public static fromJSON(element: ExportedXorFilter): XorFilter {
     const bl = new XorFilter(element._size, element._bits)
-    bl.seed = element._seed
+    bl.seed = importBigInt(element._seed)
     bl._size = element._size
     bl._blockLength = element._blockLength
     bl._filter = element._filter.map(e => importBigInt(e))

--- a/src/hashing.ts
+++ b/src/hashing.ts
@@ -1,6 +1,12 @@
-import XXH from 'xxhashjs'
-import {getDefaultSeed, HashableInput, numberToHex} from './utils'
-import {TwoHashes, TwoHashesIntAndString, TwoHashesTemplated} from './types'
+import {bigIntToNumber, getDefaultSeed} from './utils'
+import {
+  HashableInput,
+  SeedType,
+  TwoHashes,
+  TwoHashesIntAndString,
+  TwoHashesTemplated,
+} from './types'
+import {xxh64} from '@node-rs/xxhash'
 
 export default class Hashing implements Hashing {
   /**
@@ -16,11 +22,15 @@ export default class Hashing implements Hashing {
    */
   public doubleHashing(
     n: number,
-    hashA: number,
-    hashB: number,
+    hashA: bigint,
+    hashB: bigint,
     size: number
-  ): number {
-    return Math.abs((hashA + n * hashB + Math.floor((n ** 3 - n) / 6)) % size)
+  ): bigint {
+    const bigN = BigInt(n)
+    const floor = bigN ** 3n - bigN / 6n
+    const value = (hashA + bigN * hashB + floor) % BigInt(size)
+    // compute absolute value of a bigint
+    return value < 0n ? -value : value
   }
 
   /**
@@ -37,7 +47,7 @@ export default class Hashing implements Hashing {
     element: HashableInput,
     size: number,
     hashCount: number,
-    seed?: number
+    seed?: SeedType
   ): Array<number> {
     if (seed === undefined) {
       seed = getDefaultSeed()
@@ -47,7 +57,7 @@ export default class Hashing implements Hashing {
     for (let i = 0; i < hashCount; i++) {
       arr.push(this.doubleHashing(i, hashes.first, hashes.second, size))
     }
-    return arr
+    return arr.map(bigIntToNumber)
   }
 
   /**
@@ -61,11 +71,11 @@ export default class Hashing implements Hashing {
    * @param seed
    * @returns A 64bits floating point {@link Number}
    */
-  public serialize(element: HashableInput, seed?: number) {
+  public serialize(element: HashableInput, seed?: SeedType): bigint {
     if (!seed) {
       seed = getDefaultSeed()
     }
-    return XXH.h64(element, seed).toNumber()
+    return xxh64(element, seed)
   }
 
   /**
@@ -75,13 +85,13 @@ export default class Hashing implements Hashing {
    * @return The results of the hash functions applied to the value (in hex or integer)
    * @author Arnaud Grall & Thomas Minier
    */
-  public hashTwice(value: HashableInput, seed?: number): TwoHashes {
+  public hashTwice(value: HashableInput, seed?: SeedType): TwoHashes {
     if (seed === undefined) {
       seed = getDefaultSeed()
     }
     return {
-      first: this.serialize(value, seed + 1),
-      second: this.serialize(value, seed + 2),
+      first: this.serialize(value, seed + 1n),
+      second: this.serialize(value, seed + 2n),
     }
   }
 
@@ -93,31 +103,31 @@ export default class Hashing implements Hashing {
    */
   public hashTwiceAsString(
     value: HashableInput,
-    seed?: number
+    seed?: SeedType
   ): TwoHashesTemplated<string> {
     const {first, second} = this.hashTwice(value, seed)
     return {
-      first: numberToHex(first),
-      second: numberToHex(second),
+      first: first.toString(16),
+      second: second.toString(16),
     }
   }
 
   /**
    * (64-bits only) Same as hashTwice but return Numbers and String equivalent
    * @param  val the value to hash
-   * @param  seed the seed to change when hashing
+   * @param  seed - The hash seed
    * @return TwoHashesIntAndString
    * @author Arnaud Grall
    */
   public hashTwiceIntAndString(
     val: HashableInput,
-    seed?: number
+    seed?: SeedType
   ): TwoHashesIntAndString {
     if (seed === undefined) {
       seed = getDefaultSeed()
     }
-    const one = this.hashIntAndString(val, seed + 1)
-    const two = this.hashIntAndString(val, seed + 2)
+    const one = this.hashIntAndString(val, seed + 1n)
+    const two = this.hashIntAndString(val, seed + 2n)
     return {
       int: {
         first: one.int,
@@ -133,11 +143,11 @@ export default class Hashing implements Hashing {
   /**
    * Hash an item as an unsigned int
    * @param  elem - Element to hash
-   * @param  seed - The hash seed. If its is UINT32 make sure to set the length to 32
+   * @param  seed - The hash seed
    * @return The hash value as an unsigned int
    * @author Arnaud Grall
    */
-  public hashAsInt(elem: HashableInput, seed?: number): number {
+  public hashAsInt(elem: HashableInput, seed?: SeedType): bigint {
     if (seed === undefined) {
       seed = getDefaultSeed()
     }
@@ -151,8 +161,8 @@ export default class Hashing implements Hashing {
    * @return The item hased as an int and a string
    * @author Arnaud Grall
    */
-  public hashIntAndString(elem: HashableInput, seed?: number) {
+  public hashIntAndString(elem: HashableInput, seed?: SeedType) {
     const hash = this.hashAsInt(elem, seed)
-    return {int: hash, string: numberToHex(hash)}
+    return {int: hash, string: hash.toString(16)}
   }
 }

--- a/src/iblt/invertible-bloom-lookup-tables.ts
+++ b/src/iblt/invertible-bloom-lookup-tables.ts
@@ -1,8 +1,10 @@
 import BaseFilter from '../base-filter.js'
 import WritableFilter from '../interfaces/writable-filter.js'
 import Cell, {ExportedCell} from './cell.js'
-import {allocateArray} from '../utils.js'
+import {allocateArray, exportBigInt, importBigInt} from '../utils.js'
+import {ExportedBigInt} from '../types.js'
 import {xxh3} from '@node-rs/xxhash'
+import {SeedType} from '../types.js'
 
 /**
  * The reason why an Invertible Bloom Lookup Table decoding operation has failed
@@ -29,7 +31,7 @@ export type ExportedInvertibleBloomFilter = {
   _elements: ExportedCell[]
   _differences: number
   _alpha: number
-  _seed: number
+  _seed: ExportedBigInt
 }
 
 /**
@@ -60,7 +62,7 @@ export default class InvertibleBloomFilter
    * @param hashCount the number of hash functions used
    * @param seed (Optional) the seed to assign to the IBLT and its cells
    */
-  constructor(differences: number, alpha = 2, hashCount = 6, seed?: number) {
+  constructor(differences: number, alpha = 2, hashCount = 6, seed?: SeedType) {
     super()
     if (seed) {
       this.seed = seed
@@ -290,7 +292,7 @@ export default class InvertibleBloomFilter
       _elements: this._elements.map(e => e.saveAsJSON()),
       _size: this._size,
       _hashCount: this._hashCount,
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
     }
   }
 
@@ -301,7 +303,7 @@ export default class InvertibleBloomFilter
       element._differences,
       element._alpha,
       element._hashCount,
-      element._seed
+      importBigInt(element._seed)
     )
     filter._elements = element._elements.map(e => Cell.fromJSON(e))
     return filter

--- a/src/sketch/hyperloglog.ts
+++ b/src/sketch/hyperloglog.ts
@@ -1,6 +1,6 @@
 import BaseFilter from '../base-filter.js'
-import {allocateArray} from '../utils.js'
-import {HashableInput} from '../types.js'
+import {allocateArray, exportBigInt, importBigInt} from '../utils.js'
+import {ExportedBigInt, HashableInput} from '../types.js'
 import {xxh3} from '@node-rs/xxhash'
 
 // 2^32, computed as a constant as we use it a lot in the HyperLogLog algorithm
@@ -28,7 +28,7 @@ function computeAlpha(m: number): number {
 }
 
 export type ExportedHyperLogLog = {
-  _seed: number
+  _seed: ExportedBigInt
   _m: number
   _b: number
   _correctionBias: number
@@ -195,13 +195,13 @@ export default class HyperLogLog extends BaseFilter {
       _b: this._b,
       _correctionBias: this._correctionBias,
       _registers: this._registers,
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
     }
   }
 
   public static fromJSON(element: ExportedHyperLogLog): HyperLogLog {
     const filter = new HyperLogLog(element._m)
-    filter.seed = element._seed
+    filter.seed = importBigInt(element._seed)
     filter._correctionBias = element._correctionBias
     filter._b = element._b
     filter._registers = element._registers

--- a/src/sketch/min-hash.ts
+++ b/src/sketch/min-hash.ts
@@ -1,8 +1,9 @@
 import BaseFilter from '../base-filter'
-import {allocateArray} from '../utils'
+import {ExportedBigInt} from '../types'
+import {allocateArray, exportBigInt, importBigInt} from '../utils'
 
 export type ExportedMinHash = {
-  _seed: number
+  _seed: ExportedBigInt
   _nbHashes: number
   _hashFunctions: HashFunction[]
   _signature: number[]
@@ -135,13 +136,13 @@ export default class MinHash extends BaseFilter {
       _hashFunctions: this._hashFunctions,
       _nbHashes: this._nbHashes,
       _signature: this._signature,
-      _seed: this._seed,
+      _seed: exportBigInt(this._seed),
     }
   }
 
   public static fromJSON(element: ExportedMinHash): MinHash {
     const filter = new MinHash(element._nbHashes, element._hashFunctions)
-    filter.seed = element._seed
+    filter.seed = importBigInt(element._seed)
     filter._signature = element._signature
     return filter
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,8 @@
  * @memberof Utils
  */
 export interface TwoHashes {
-  first: number // bigint
-  second: number // bigint
+  first: bigint
+  second: bigint
 }
 
 /**
@@ -21,7 +21,7 @@ export interface TwoHashesTemplated<T> {
  * TwoHashes type in bigint and int format
  */
 export interface TwoHashesIntAndString {
-  int: TwoHashesTemplated<number> // TwoHashesTemplated<bigint>
+  int: TwoHashesTemplated<bigint>
   string: TwoHashesTemplated<string>
 }
 
@@ -33,4 +33,7 @@ export type HashableInput = string | Uint8Array
 /**
  * Type of the seed used in this package
  */
-export type SeedType = number
+export type SeedType = bigint
+export type ExportedBigInt = {
+  $bf$bigint: string
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,4 @@
-/**
- * Data type of an hashable value, must be string, ArrayBuffer or Buffer.
- */
-export type HashableInput = string | ArrayBuffer | Buffer
+import {ExportedBigInt} from './types'
 
 /**
  * Create a new array fill with a base value
@@ -79,11 +76,11 @@ export function isEmptyBuffer(buffer: Buffer | null): boolean {
 
 /**
  * Return the default seed used in the package
- * @return A seed as a floating point number
+ * @return A seed as a big integer
  * @author Arnaud Grall
  */
-export function getDefaultSeed(): number {
-  return 0x1234567890
+export function getDefaultSeed(): bigint {
+  return 0x1234567890n
 }
 
 /**
@@ -137,10 +134,6 @@ export function arraysEqual(a: Uint8Array, b: Uint8Array): boolean {
  */
 export function getBigIntAbs(n: bigint): bigint {
   return n < 0n ? -n : n
-}
-
-export type ExportedBigInt = {
-  $bf$bigint: string
 }
 
 /**

--- a/tests/bloom-filter.test.ts
+++ b/tests/bloom-filter.test.ts
@@ -1,9 +1,11 @@
 import {expect, test, describe} from '@jest/globals'
 import BloomFilter from 'bloom-filters/bloom/bloom-filter'
+import {exportBigInt, getDefaultSeed} from 'bloom-filters/utils'
+import {getNewSeed} from './common'
 
 describe('BloomFilter', () => {
   const targetRate = 0.1
-  const seed = Math.random()
+  const seed = getNewSeed()
 
   describe('construction', () => {
     test('should add element to the filter with #add', () => {
@@ -30,7 +32,7 @@ describe('BloomFilter', () => {
       expect(filter.length).toBeGreaterThan(0)
       expect(filter.length).toBeLessThanOrEqual(filter._nbHashes * data.length)
       expect(filter.rate()).toBeCloseTo(targetRate, 0.1)
-      expect(filter.seed).toEqual(0x1234567890) // utils.getDefaultSeed()
+      expect(filter.seed).toEqual(getDefaultSeed())
     })
   })
 
@@ -81,7 +83,7 @@ describe('BloomFilter', () => {
     const filter = BloomFilter.from(['alice', 'bob', 'carl'], targetRate, seed)
     test('should export a bloom filter to a JSON object', () => {
       const exported = filter.saveAsJSON()
-      expect(exported._seed).toEqual(filter.seed)
+      expect(exported._seed).toEqual(exportBigInt(filter.seed))
       expect(exported._size).toEqual(filter.size)
       expect(exported._nbHashes).toEqual(filter._nbHashes)
       expect(exported._filter).toEqual(filter._filter.export())
@@ -101,7 +103,7 @@ describe('BloomFilter', () => {
   })
 
   describe('Performance test', () => {
-    const max = 1000
+    const max = 10000
     const targetedRate = 0.01
     test(`should not return an error when inserting ${max} elements`, () => {
       const filter = BloomFilter.create(max, targetedRate)

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,0 +1,5 @@
+import {randomInt} from 'bloom-filters/utils'
+
+export function getNewSeed() {
+  return BigInt(randomInt(1, Number.MAX_SAFE_INTEGER))
+}

--- a/tests/counting-bloom-filter.test.ts
+++ b/tests/counting-bloom-filter.test.ts
@@ -1,5 +1,6 @@
 import {expect, test, describe} from '@jest/globals'
 import CountingBloomFilter from 'bloom-filters/bloom/counting-bloom-filter'
+import {exportBigInt} from 'bloom-filters/utils'
 
 describe('CountingBloomFilter', () => {
   const targetRate = 0.1
@@ -102,7 +103,7 @@ describe('CountingBloomFilter', () => {
     test('should export a bloom filter to a JSON object', () => {
       const filter = getFilter()
       const exported = filter.saveAsJSON()
-      expect(exported._seed).toEqual(filter.seed)
+      expect(exported._seed).toEqual(exportBigInt(filter.seed))
       expect(exported._size).toEqual(filter.size)
       expect(exported._length).toEqual(filter.length)
       expect(exported._nbHashes).toEqual(filter._nbHashes)

--- a/tests/cuckoo-filter.test.ts
+++ b/tests/cuckoo-filter.test.ts
@@ -1,5 +1,6 @@
 import {expect, test, describe} from '@jest/globals'
 import CuckooFilter from 'bloom-filters/cuckoo/cuckoo-filter'
+import {bigIntToNumber} from 'bloom-filters/utils'
 
 describe('CuckooFilter', () => {
   describe('#_locations', () => {
@@ -10,16 +11,19 @@ describe('CuckooFilter', () => {
       const hash = hashes.int
       const fingerprint = hashes.string.substring(0, 3)
 
-      const firstIndex = Math.abs(hash)
-      const secondIndex = Math.abs(
-        firstIndex ^
-          Math.abs(filter._hashing.hashAsInt(fingerprint, filter.seed))
-      )
-
+      const firstIndex = hash < 0 ? -hash : hash
+      let secondHash = filter._hashing.hashAsInt(fingerprint, filter.seed)
+      secondHash = secondHash < 0 ? -secondHash : secondHash
+      let secondIndex = firstIndex ^ secondHash
+      secondIndex = secondIndex < 0 ? -secondIndex : secondIndex
       const locations = filter._locations(element)
       expect(locations.fingerprint).toBe(fingerprint)
-      expect(locations.firstIndex).toBe(firstIndex % filter.size)
-      expect(locations.secondIndex).toBe(secondIndex % filter.size)
+      expect(locations.firstIndex).toBe(
+        bigIntToNumber(firstIndex % BigInt(filter.size))
+      )
+      expect(locations.secondIndex).toBe(
+        bigIntToNumber(secondIndex % BigInt(filter.size))
+      )
     })
   })
 

--- a/tests/iblt.test.ts
+++ b/tests/iblt.test.ts
@@ -1,9 +1,10 @@
 import {expect, test, describe} from '@jest/globals'
 import InvertibleBloomFilter from 'bloom-filters/iblt/invertible-bloom-lookup-tables'
-import {randomInt} from 'bloom-filters/utils'
+import {exportBigInt, randomInt} from 'bloom-filters/utils'
 import random from 'random'
 import range from 'lodash/range'
 import seedrandom from 'seedrandom'
+import {getNewSeed} from './common'
 
 describe('Invertible Bloom Lookup Tables', () => {
   const keys = 1000
@@ -12,7 +13,7 @@ describe('Invertible Bloom Lookup Tables', () => {
   const d = 100
   let size = Math.ceil(alpha * d)
   size = size + (hashCount - (size % hashCount))
-  const seed = 0x1234567890
+  const seed = getNewSeed()
   random.use(seedrandom('' + seed))
   const toInsert = [
     'help',
@@ -104,7 +105,7 @@ describe('Invertible Bloom Lookup Tables', () => {
       iblt.add(e)
     })
     const exported = iblt.saveAsJSON()
-    expect(exported._seed).toEqual(seed)
+    expect(exported._seed).toEqual(exportBigInt(seed))
     expect(exported._size).toEqual(iblt._size)
     expect(exported._hashCount).toEqual(iblt._hashCount)
     expect(exported._alpha).toEqual(iblt._alpha)
@@ -118,13 +119,23 @@ describe('Invertible Bloom Lookup Tables', () => {
 
   describe(`Multiple run with different seeds for d=${d}`, () => {
     range(0, 10)
-      .map(r => [r, randomInt(1, Number.MAX_SAFE_INTEGER)])
+      .map(r => [r, BigInt(randomInt(1, Number.MAX_SAFE_INTEGER))])
       .forEach(([r, seed]) => {
         test(`should decodes correctly elements (run ${r} with seed ${seed})`, () => {
-          const iblt = new InvertibleBloomFilter(d, alpha, hashCount, seed)
+          const iblt = new InvertibleBloomFilter(
+            d,
+            alpha,
+            hashCount,
+            seed as bigint
+          )
           const setDiffplus: string[] = []
           const setDiffminus: string[] = []
-          const remote = new InvertibleBloomFilter(d, alpha, hashCount, seed)
+          const remote = new InvertibleBloomFilter(
+            d,
+            alpha,
+            hashCount,
+            seed as bigint
+          )
           for (let i = 0; i < keys; ++i) {
             const hash = i.toString()
             if (i < keys - d) {

--- a/tests/scalable-bloom-filter.test.ts
+++ b/tests/scalable-bloom-filter.test.ts
@@ -1,9 +1,10 @@
 import {expect, test, describe} from '@jest/globals'
 import ScalableBloomFilter from 'bloom-filters/bloom/scalable-bloom-filter'
+import {getNewSeed} from './common'
 
 describe('ScalableBloomFilter', () => {
   const targetRate = 0.1
-  const seed = Math.random()
+  const seed = getNewSeed()
 
   describe('construction', () => {
     test('should #add add elements without error', () => {
@@ -62,7 +63,7 @@ describe('ScalableBloomFilter', () => {
       filter._filters.forEach(f => {
         expect(f.seed).toEqual(seed)
       })
-      expect(filter._filters.length).toEqual(7)
+      expect(filter._filters.length).toEqual(6)
     })
 
     test('should import/export correctly', () => {

--- a/tests/topk.test.ts
+++ b/tests/topk.test.ts
@@ -1,5 +1,6 @@
 import {expect, test, describe} from '@jest/globals'
 import TopK, {TopkElement} from 'bloom-filters/sketch/topk'
+import {exportBigInt, getDefaultSeed} from 'bloom-filters/utils'
 
 describe('TopK', () => {
   const lessThanOrEqualTestCaseItems = [
@@ -228,6 +229,17 @@ describe('TopK', () => {
     })
   })
 
+  describe('#seed', () => {
+    test('should declare the same seed for the internal sketch', () => {
+      let topk = new TopK(3, 0.001, 0.999)
+      expect(topk.seed).toEqual(getDefaultSeed())
+      expect(topk._sketch.seed).toEqual(getDefaultSeed())
+      topk = new TopK(3, 0.001, 0.999, 1n)
+      expect(topk.seed).toEqual(1n)
+      expect(topk._sketch.seed).toEqual(1n)
+    })
+  })
+
   describe('#saveAsJSON', () => {
     const topk = new TopK(3, 0.001, 0.999)
     topk.add('alice')
@@ -242,12 +254,12 @@ describe('TopK', () => {
       expect(exported._k).toEqual(topk._k)
       expect(exported._errorRate).toEqual(topk._errorRate)
       expect(exported._accuracy).toEqual(topk._accuracy)
-      expect(exported._seed).toEqual(topk._seed)
+      expect(exported._seed).toEqual(exportBigInt(topk._seed))
       // inner count min sketch
       expect(exported._sketch._columns).toEqual(topk._sketch._columns)
       expect(exported._sketch._rows).toEqual(topk._sketch._rows)
       expect(exported._sketch._allSums).toEqual(topk._sketch._allSums)
-      expect(exported._sketch._seed).toEqual(topk._sketch._seed)
+      expect(exported._sketch._seed).toEqual(exportBigInt(topk._sketch._seed))
       expect(exported._sketch._matrix).toEqual(topk._sketch._matrix)
       // inner MinHeap
       expect(exported._heap._content).toEqual(topk._heap._content)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,11 +1481,6 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cuint@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz"
-  integrity sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==
-
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
@@ -3801,13 +3796,6 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
-
-xxhashjs@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz"
-  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
-  dependencies:
-    cuint "^0.2.2"
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
## Changes

* Remove xxhashjs
* Use @node-rs/xxhash everywhere
  * Since xxh64 returns bigint(s) we now use bigints everywhere. 

The critical part are:
* doubleHashing
  * depending on your review, we may want to return only numbers because the produced nhash should be on `[0, tableSize)`. And will probably never be higher than Number.MAX_SAFE_INTEGER which is `9007199254740991` in node 22 😆 . Aka we will call `bigIntToNumber()` directly in the function.
* cuckoo indexes creation

